### PR TITLE
[FIX] Fix detection of multiple (i.e. more than one) sms type

### DIFF
--- a/app/src/main/java/de/bikebean/app/db/type/types/ParserPatterns.kt
+++ b/app/src/main/java/de/bikebean/app/db/type/types/ParserPatterns.kt
@@ -12,13 +12,16 @@ object ParserPatterns {
             "(Warningnumber: )([+0-9]{8,})"
     )
     var statusNoWarningNumberPattern: Pattern = Pattern.compile(
-            "(Warningnumber: )"
+            "(Warningnumber: )(no number set)"
     )
     var statusIntervalPattern: Pattern = Pattern.compile(
             "(Interval: )(1|2|4|8|12|24)(h)"
     )
-    var statusWifiStatusPattern: Pattern = Pattern.compile(
-            "(Wifi Status: )(on|off)"
+    var statusWifiStatusOffPattern: Pattern = Pattern.compile(
+            "(Wifi Status: )(off)"
+    )
+    var statusWifiStatusOnPattern: Pattern = Pattern.compile(
+            "(Wifi Status: )(on)"
     )
     var statusBatteryStatusPattern: Pattern = Pattern.compile(
             "(Battery Status: )([0-9]{1,3})(%)"

--- a/app/src/main/java/de/bikebean/app/db/type/types/ParserType.kt
+++ b/app/src/main/java/de/bikebean/app/db/type/types/ParserType.kt
@@ -26,7 +26,6 @@ abstract class ParserType(
     /* Get results of Sms Parser */
     protected val Matcher.battery: Double get() = result.toDoubleSafe()
     protected val Matcher.batterySimple: Double get() = resultSimple
-    protected val Matcher.wifi : Boolean get() = result == "on"
     protected val Matcher.interval : Int get() = result.toInt()
 
     protected fun String.toDoubleSafe() = when {
@@ -88,7 +87,8 @@ abstract class ParserType(
         }
 
     enum class TYPE {
-        POSITION, STATUS, STATUS_NO_WARNING_NUMBER, STATUS_NO_WARNING_NUMBER_WIFI_ON,
+        POSITION, STATUS_WIFI_OFF, STATUS_WIFI_ON,
+        STATUS_NO_WARNING_NUMBER_WIFI_OFF, STATUS_NO_WARNING_NUMBER_WIFI_ON,
         WIFI_ON, WIFI_OFF, WARNING_NUMBER,
         CELL_TOWERS, WIFI_LIST, NO_WIFI_LIST, NO_WIFI_LIST_ALT,
         INT, LOW_BATTERY, VERY_LOW_BATTERY

--- a/app/src/main/java/de/bikebean/app/db/type/types/ParserTypeFactory.kt
+++ b/app/src/main/java/de/bikebean/app/db/type/types/ParserTypeFactory.kt
@@ -12,8 +12,9 @@ object ParserTypeFactory {
 
     private fun typesToCheck(sms: Sms, lv: WeakReference<LogViewModel>) = listOf(
             Position(sms, lv),
-            StatusType(sms, lv),
-            StatusTypeNoWarningNumber(sms, lv),
+            StatusTypeWifiOff(sms, lv),
+            StatusTypeWifiOn(sms, lv),
+            StatusTypeNoWarningNumberWifiOff(sms, lv),
             StatusTypeNoWarningNumberWifiOn(sms, lv),
             WifiOn(sms, lv),
             WifiOff(sms, lv),

--- a/app/src/main/java/de/bikebean/app/db/type/types/sms_parser_types/StatusTypeNoWarningNumberWifiOff.kt
+++ b/app/src/main/java/de/bikebean/app/db/type/types/sms_parser_types/StatusTypeNoWarningNumberWifiOff.kt
@@ -6,37 +6,35 @@ import de.bikebean.app.db.settings.settings.replace_if_newer_settings.Status
 import de.bikebean.app.db.settings.settings.replace_if_newer_settings.WarningNumber
 import de.bikebean.app.db.settings.settings.replace_if_newer_settings.Wifi
 import de.bikebean.app.db.sms.Sms
-import de.bikebean.app.db.type.types.ParserPatterns.statusBatteryStatusPatternShort
+import de.bikebean.app.db.type.types.ParserPatterns.statusBatteryStatusPattern
 import de.bikebean.app.db.type.types.ParserPatterns.statusIntervalPattern
 import de.bikebean.app.db.type.types.ParserPatterns.statusNoWarningNumberPattern
-import de.bikebean.app.db.type.types.ParserPatterns.statusWifiStatusOnPattern
+import de.bikebean.app.db.type.types.ParserPatterns.statusWifiStatusOffPattern
 import de.bikebean.app.db.type.types.ParserType
 import de.bikebean.app.ui.drawer.log.LogViewModel
 import java.lang.ref.WeakReference
 
-// This class is a (temporary?) fix to cope with https://github.com/bike-bean/Bike-Bean/pull/6
-
-class StatusTypeNoWarningNumberWifiOn(
+class StatusTypeNoWarningNumberWifiOff(
         sms: Sms, lv: WeakReference<LogViewModel>
-) : ParserType(TYPE.STATUS_NO_WARNING_NUMBER_WIFI_ON, sms, lv) {
+) : ParserType(TYPE.STATUS_NO_WARNING_NUMBER_WIFI_OFF, sms, lv) {
 
     private val statusNoWarningNumberMatcher = statusNoWarningNumberPattern.matcher(sms.body)
     private val statusIntervalMatcher = statusIntervalPattern.matcher(sms.body)
-    private val statusWifiStatusOnMatcher = statusWifiStatusOnPattern.matcher(sms.body)
-    private val statusBatteryStatusMatcherShort = statusBatteryStatusPatternShort.matcher(sms.body)
+    private val statusWifiStatusOffMatcher = statusWifiStatusOffPattern.matcher(sms.body)
+    private val statusBatteryStatusMatcher = statusBatteryStatusPattern.matcher(sms.body)
 
     override val matchers = listOf(
             statusNoWarningNumberMatcher,
-            statusBatteryStatusMatcherShort,
-            statusIntervalMatcher,
-            statusWifiStatusOnMatcher
+            statusBatteryStatusMatcher,
+            statusWifiStatusOffMatcher,
+            statusIntervalMatcher
     )
 
     override val settings get() = listOf(
             WarningNumber(sms),
             Interval(sms, statusIntervalMatcher.interval),
-            Wifi(sms, true),
-            Battery(sms, statusBatteryStatusMatcherShort.batterySimple),
+            Wifi(sms, false),
+            Battery(sms, statusBatteryStatusMatcher.battery),
             Status(sms)
     )
 }

--- a/app/src/main/java/de/bikebean/app/db/type/types/sms_parser_types/StatusTypeWifiOff.kt
+++ b/app/src/main/java/de/bikebean/app/db/type/types/sms_parser_types/StatusTypeWifiOff.kt
@@ -9,29 +9,29 @@ import de.bikebean.app.db.sms.Sms
 import de.bikebean.app.db.type.types.ParserPatterns.statusBatteryStatusPattern
 import de.bikebean.app.db.type.types.ParserPatterns.statusIntervalPattern
 import de.bikebean.app.db.type.types.ParserPatterns.statusWarningNumberPattern
-import de.bikebean.app.db.type.types.ParserPatterns.statusWifiStatusPattern
+import de.bikebean.app.db.type.types.ParserPatterns.statusWifiStatusOffPattern
 import de.bikebean.app.db.type.types.ParserType
 import de.bikebean.app.ui.drawer.log.LogViewModel
 import java.lang.ref.WeakReference
 
-class StatusType(sms: Sms, lv: WeakReference<LogViewModel>) : ParserType(TYPE.STATUS, sms, lv) {
+class StatusTypeWifiOff(sms: Sms, lv: WeakReference<LogViewModel>) : ParserType(TYPE.STATUS, sms, lv) {
 
     private val statusWarningNumberMatcher = statusWarningNumberPattern.matcher(sms.body)
     private val statusIntervalMatcher = statusIntervalPattern.matcher(sms.body)
-    private val statusWifiStatusMatcher = statusWifiStatusPattern.matcher(sms.body)
+    private val statusWifiStatusOffMatcher = statusWifiStatusOffPattern.matcher(sms.body)
     private val statusBatteryStatusMatcher = statusBatteryStatusPattern.matcher(sms.body)
 
     override val matchers = listOf(
             statusWarningNumberMatcher,
             statusIntervalMatcher,
-            statusWifiStatusMatcher,
+            statusWifiStatusOffMatcher,
             statusBatteryStatusMatcher
     )
 
     override val settings get() = listOf(
             WarningNumber(sms, statusWarningNumberMatcher.result),
             Interval(sms, statusIntervalMatcher.interval),
-            Wifi(sms, statusWifiStatusMatcher.wifi),
+            Wifi(sms, false),
             Battery(sms, statusBatteryStatusMatcher.battery),
             Status(sms)
     )

--- a/app/src/main/java/de/bikebean/app/db/type/types/sms_parser_types/StatusTypeWifiOn.kt
+++ b/app/src/main/java/de/bikebean/app/db/type/types/sms_parser_types/StatusTypeWifiOn.kt
@@ -8,33 +8,32 @@ import de.bikebean.app.db.settings.settings.replace_if_newer_settings.Wifi
 import de.bikebean.app.db.sms.Sms
 import de.bikebean.app.db.type.types.ParserPatterns.statusBatteryStatusPattern
 import de.bikebean.app.db.type.types.ParserPatterns.statusIntervalPattern
-import de.bikebean.app.db.type.types.ParserPatterns.statusNoWarningNumberPattern
-import de.bikebean.app.db.type.types.ParserPatterns.statusWifiStatusPattern
+import de.bikebean.app.db.type.types.ParserPatterns.statusWarningNumberPattern
+import de.bikebean.app.db.type.types.ParserPatterns.statusWifiStatusOnPattern
 import de.bikebean.app.db.type.types.ParserType
 import de.bikebean.app.ui.drawer.log.LogViewModel
 import java.lang.ref.WeakReference
 
-class StatusTypeNoWarningNumber(
-        sms: Sms, lv: WeakReference<LogViewModel>
-) : ParserType(TYPE.STATUS_NO_WARNING_NUMBER, sms, lv) {
+class StatusTypeWifiOn(sms: Sms, lv: WeakReference<LogViewModel>) : ParserType(TYPE.STATUS_WIFI_ON, sms, lv) {
 
-    private val statusNoWarningNumberMatcher = statusNoWarningNumberPattern.matcher(sms.body)
+    private val statusWarningNumberMatcher = statusWarningNumberPattern.matcher(sms.body)
     private val statusIntervalMatcher = statusIntervalPattern.matcher(sms.body)
-    private val statusWifiStatusMatcher = statusWifiStatusPattern.matcher(sms.body)
+    private val statusWifiStatusOnMatcher = statusWifiStatusOnPattern.matcher(sms.body)
     private val statusBatteryStatusMatcher = statusBatteryStatusPattern.matcher(sms.body)
 
     override val matchers = listOf(
-            statusNoWarningNumberMatcher,
-            statusBatteryStatusMatcher,
+            statusWarningNumberMatcher,
             statusIntervalMatcher,
-            statusWifiStatusMatcher
+            statusWifiStatusOnMatcher,
+            statusBatteryStatusMatcher
     )
 
     override val settings get() = listOf(
-            WarningNumber(sms),
+            WarningNumber(sms, statusWarningNumberMatcher.result),
             Interval(sms, statusIntervalMatcher.interval),
-            Wifi(sms, statusWifiStatusMatcher.wifi),
+            Wifi(sms, true),
             Battery(sms, statusBatteryStatusMatcher.battery),
             Status(sms)
     )
+
 }

--- a/doc/Doc.md
+++ b/doc/Doc.md
@@ -38,7 +38,7 @@ To test the SMS API, use the following strings:
 | SMS Befehl    | Text |
 | ------------- | ------------------------------------ |
 | Pos           | 262,03,55f1,a473,36<br>262,03,55f1,5653,21<br>262,03,55f1,4400,20<br>262,03,55f1,8b40,12<br>262,03,55f1,6bb2,10<br>262,03,55f1,0833,09<br>262,03,55f1,6bcd,03<br>.............<br>Battery Status: 30% |
-| Status        | Warningnumber: 015112345678<br>Interval: 12h<br>Wifi Status: on<br>Battery Status: 90% |
+| Status        | Warningnumber: 015112345678<br>Interval: 12h<br>Wifi Status: off<br>Battery Status: 90% |
 | Wifi on       | Fancy Wifi SSID,30<br>Another Wifi SSID,60<br>Wifi is on!<br>Battery Status: 5% |
 | Wifi off      | Wifi Off<br>Battery Status: 100% |
 | Warningnumber | Warningnumber has been changed to 0179987654321<br>Battery Status: 15% |
@@ -48,3 +48,6 @@ To test the SMS API, use the following strings:
 | Low Battery   | BATTERY LOW!<br>BATTERY STATUS: 19% |
 | Very Low Battery | BATTERY LOW!<br>BATTERY STATUS: 8% <br>Interval set to 24h |
 | No Wifi Available | no wifi available<br>88 |
+| No Warning number set | Warningnumber: no number set<br>Interval: 12h<br>Wifi Status: off<br>Battery Status: 90% |
+| Wifi is on (bike-bean/Bike-Bean#6) | Warningnumber: 015112345678<br>Interval: 12h<br>Wifi Status: on<br>90% |
+| Wifi is on & no warning number | Warningnumber: no number set<br>Interval: 12h<br>Wifi Status: on<br>90% |


### PR DESCRIPTION
Some message were detected as more than one type due to the types not being distinct enough.